### PR TITLE
Removed un-used imports

### DIFF
--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/core/clsmgr/FolderSourceList.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/core/clsmgr/FolderSourceList.java
@@ -2,7 +2,6 @@ package com.innowhere.relproxy.impl.jproxy.core.clsmgr;
 
 import com.innowhere.relproxy.RelProxyException;
 import com.innowhere.relproxy.impl.FileExt;
-import com.innowhere.relproxy.impl.jproxy.JProxyUtil;
 import java.io.File;
 
 /**

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/core/clsmgr/comp/JProxyCompilerInMemory.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/core/clsmgr/comp/JProxyCompilerInMemory.java
@@ -10,9 +10,6 @@ import com.innowhere.relproxy.impl.jproxy.core.clsmgr.cldesc.ClassDescriptorSour
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.cldesc.ClassDescriptorSourceFileJava;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.cldesc.ClassDescriptorSourceFileRegistry;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.cldesc.ClassDescriptorSourceScript;
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.FolderSourceList;
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.JProxyClassLoader;
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.JProxyEngine;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.JProxyEngineChangeDetectorAndCompiler;
 import com.innowhere.relproxy.jproxy.JProxyDiagnosticsListener;
 import java.io.File;

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/core/clsmgr/comp/jfo/JavaFileObjectInputClassInMemory.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/core/clsmgr/comp/jfo/JavaFileObjectInputClassInMemory.java
@@ -1,7 +1,6 @@
 package com.innowhere.relproxy.impl.jproxy.core.clsmgr.comp.jfo;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/core/clsmgr/srcunit/SourceFileJavaNormal.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/core/clsmgr/srcunit/SourceFileJavaNormal.java
@@ -1,7 +1,6 @@
 package com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit;
 
 import com.innowhere.relproxy.impl.FileExt;
-import java.io.File;
 
 /**
  *

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/core/clsmgr/srcunit/SourceScriptRootFile.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/core/clsmgr/srcunit/SourceScriptRootFile.java
@@ -3,7 +3,6 @@ package com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit;
 import com.innowhere.relproxy.impl.FileExt;
 import com.innowhere.relproxy.impl.jproxy.JProxyUtil;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.FolderSourceList;
-import java.io.File;
 
 /**
  *

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/screngine/JProxyScriptEngineDelegateImpl.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/screngine/JProxyScriptEngineDelegateImpl.java
@@ -4,7 +4,6 @@ import com.innowhere.relproxy.RelProxyException;
 import com.innowhere.relproxy.impl.jproxy.JProxyConfigImpl;
 import com.innowhere.relproxy.impl.jproxy.core.JProxyImpl;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.cldesc.ClassDescriptorSourceScript;
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.FolderSourceList;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.JProxyEngine;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit.SourceScriptRoot;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit.SourceScriptRootInMemory;

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/JProxyShellImpl.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/JProxyShellImpl.java
@@ -3,13 +3,10 @@ package com.innowhere.relproxy.impl.jproxy.shell;
 import com.innowhere.relproxy.RelProxyException;
 import com.innowhere.relproxy.RelProxyOnReloadListener;
 import com.innowhere.relproxy.impl.jproxy.JProxyConfigImpl;
-import com.innowhere.relproxy.impl.jproxy.JProxyUtil;
 import com.innowhere.relproxy.impl.jproxy.core.JProxyImpl;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.cldesc.ClassDescriptorSourceScript;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.FolderSourceList;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit.SourceScriptRoot;
-import com.innowhere.relproxy.jproxy.JProxyInputSourceFileExcludedListener;
-import java.io.File;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
 

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/JProxyShellInteractiveImpl.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/JProxyShellInteractiveImpl.java
@@ -7,7 +7,6 @@ import com.innowhere.relproxy.impl.jproxy.core.clsmgr.FolderSourceList;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit.SourceScriptRoot;
 import com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit.SourceScriptRootInMemory;
 import com.innowhere.relproxy.impl.jproxy.shell.inter.JProxyShellProcessor;
-import java.io.File;
 import java.util.LinkedList;
 
 /**

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/CommandCodeChangerBase.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/CommandCodeChangerBase.java
@@ -1,9 +1,5 @@
 package com.innowhere.relproxy.impl.jproxy.shell.inter;
 
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.cldesc.ClassDescriptorSourceScript;
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit.SourceScriptRootInMemory;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.Command.getParameter;
-
 
 /**
  *

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/CommandDelete.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/CommandDelete.java
@@ -1,9 +1,5 @@
 package com.innowhere.relproxy.impl.jproxy.shell.inter;
 
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.cldesc.ClassDescriptorSourceScript;
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit.SourceScriptRootInMemory;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.Command.getParameter;
-
 
 /**
  *

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/CommandEdit.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/CommandEdit.java
@@ -1,17 +1,5 @@
 package com.innowhere.relproxy.impl.jproxy.shell.inter;
 
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.cldesc.ClassDescriptorSourceScript;
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit.SourceScriptRootInMemory;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.Command.getParameter;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_LAST_REQUIRED;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_LINE_1_NOT_VALID;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_NOT_A_NUMBER;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_NO_LAST_LINE;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_OUT_OF_RANGE;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_VALUE_NOT_0_OR_NEGATIVE;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.getLineFromParam;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandDelete.NAME;
-
 
 /**
  *

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/CommandInsert.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/CommandInsert.java
@@ -1,17 +1,5 @@
 package com.innowhere.relproxy.impl.jproxy.shell.inter;
 
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.cldesc.ClassDescriptorSourceScript;
-import com.innowhere.relproxy.impl.jproxy.core.clsmgr.srcunit.SourceScriptRootInMemory;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.Command.getParameter;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_LAST_REQUIRED;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_LINE_1_NOT_VALID;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_NOT_A_NUMBER;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_NO_LAST_LINE;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_OUT_OF_RANGE;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.ERROR_VALUE_NOT_0_OR_NEGATIVE;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandCodeChangerBase.getLineFromParam;
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.CommandEdit.NAME;
-
 
 /**
  *

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/Keyboard.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/Keyboard.java
@@ -1,6 +1,5 @@
 package com.innowhere.relproxy.impl.jproxy.shell.inter;
 
-import static com.innowhere.relproxy.impl.jproxy.shell.inter.KeyboardNotUsingClipboard.create;
 import java.nio.charset.Charset;
 
 /**

--- a/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/WindowUnicodeKeyboard.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/impl/jproxy/shell/inter/WindowUnicodeKeyboard.java
@@ -1,16 +1,6 @@
 package com.innowhere.relproxy.impl.jproxy.shell.inter;
 
 import static java.awt.event.KeyEvent.VK_ALT;
-import static java.awt.event.KeyEvent.VK_NUMPAD0;
-import static java.awt.event.KeyEvent.VK_NUMPAD1;
-import static java.awt.event.KeyEvent.VK_NUMPAD2;
-import static java.awt.event.KeyEvent.VK_NUMPAD3;
-import static java.awt.event.KeyEvent.VK_NUMPAD4;
-import static java.awt.event.KeyEvent.VK_NUMPAD5;
-import static java.awt.event.KeyEvent.VK_NUMPAD6;
-import static java.awt.event.KeyEvent.VK_NUMPAD7;
-import static java.awt.event.KeyEvent.VK_NUMPAD8;
-import static java.awt.event.KeyEvent.VK_NUMPAD9;
 import java.nio.charset.Charset;
 
 /**

--- a/relproxy/src/main/java/com/innowhere/relproxy/jproxy/JProxyScriptEngine.java
+++ b/relproxy/src/main/java/com/innowhere/relproxy/jproxy/JProxyScriptEngine.java
@@ -1,6 +1,5 @@
 package com.innowhere.relproxy.jproxy;
 
-import com.innowhere.relproxy.impl.jproxy.JProxyDefaultImpl;
 import javax.script.ScriptEngine;
 
 /**


### PR DESCRIPTION
This removes all un-used imports (which causes less noisy warnings in Eclipse).

Sorry for the screwed up line ending, you can see the actual diff better when using https://github.com/jmarranz/relproxy/pull/4/files?w=1 .. let me know if you need a clean diff and this is un-acceptable to you.